### PR TITLE
Added information proxy configuration for versions >= 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,23 @@ browserSync.init(['css/*.css'], {
 Depending on what version of Browser Sync you're using, you will need to alter this configuration slightly.
 To check what version you're running, use: `npm view browser-sync version`
 
+When running Browser Sync versions prior to 0.7.0, use the following:
 ```js
-// Watch CSS files and use the proxy with your own server. (For browser-sync versions < 0.7.0)
+// Watch CSS files and use the proxy with your own server.
 browserSync.init(['css/*.css'], {
 	proxy: {
 		host: 'mylocal.dev',
 		port: '8000'
 	}
 });
+```
 
-// Watch CSS files and use the proxy with your own server. (For browser-sync versions >= 0.7.0)
+When running Browser Sync versions of 0.7.0 or higher, use the following:
+```js
+// Watch CSS files and use the proxy with your own server.
 browserSync.init(['css/*.css'], {
 	proxy: 'mylocal.dev:8000'
 });
-
-
 ```
 
 **Using along-side other watch tasks (SASS)**


### PR DESCRIPTION
Added an extra example when using the proxy option with Browser Sync versions >= 0.7.0 based on the original Browser Sync documentation. This to avoid confusion when using the plugin.
